### PR TITLE
NodeJS and node-midi compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   "author": "Nicolas Froidure",
   "license": "MIT",
   "dependencies": {
-    "midievents": "^1.0.1"
+    "midievents": "^1.0.1",
+    "performance-now": "^0.2.0"
   },
   "devDependencies": {
     "browserify": "^12.0.2",


### PR DESCRIPTION
A couple minor changes to allow MIDPlayer to run on NodeJS. The listener for the ```unload``` event isn't needed with newer versions of the Web MIDI API, so I pulled it out, but it could be wrapped in a conditional (like ```if (!global)```) to maintain backward compatibility if you prefer

I also added a dependency for a Node performance.now implementation.

The library now supports passing a node-midi output object to MIDIPlayer, too. The node-midi output's ```sendMessage``` method is the equivalent the Web MIDI API's ```send``` so I just point ```send``` to ```sendMessage``` if the former is undefined. This naming inconsistency seems like it may be an upstream issue with node-midi but I addressed it as it stands now.