### PR TITLE
Fix bug in note velocity

### DIFF
--- a/src/MIDIPlayer.js
+++ b/src/MIDIPlayer.js
@@ -69,7 +69,7 @@ MIDIPlayer.prototype.processPlay = function() {
   while(this.events[this.position] && event.playTime - elapsedTime < bufferDelay) {
     param2 = 0;
     if(event.subtype === MIDIEvents.EVENT_MIDI_NOTE_ON) {
-      param2 = Math.floor(event.param1 * ((this.volume || 100) / 100));
+      param2 = Math.floor(event.param2 * ((this.volume || 100) / 100));
       this.notesOn[event.channel].push(event.param1);
     } else if(event.subtype === MIDIEvents.EVENT_MIDI_NOTE_OFF) {
       index = this.notesOn[event.channel].indexOf(event.param1);


### PR DESCRIPTION
Use velocity (param2) instead of note number (param1) in the volume multiplication.
This bug caused most songs to be played too quietly, as note numbers are typically lower than note velocity.